### PR TITLE
feat: redesign GitHub page with language stats and improved timeline

### DIFF
--- a/src/components/GithubLanguage.tsx
+++ b/src/components/GithubLanguage.tsx
@@ -1,35 +1,124 @@
-import { Col, Image, Row } from "antd";
+import { useEffect, useState } from "react";
 import { Props } from "../interfaces/globalInterfaces";
 import { motion } from "framer-motion";
 
-export default function GithubLangauge({ isComp }: Props) {
-    const githubLanguageUrl = 'https://github-readme-stats.vercel.app/api/top-langs/?username=Nathapons&layout=compact&theme=vision-friendly-dark&bg_color=171721&hide_border=true&title_color=fbbd23&text_color=c6c6c6'
-    const githubStatUrl = 'https://github-readme-stats.vercel.app/api?username=Nathapons&show_icons=true&theme=vision-friendly-dark&bg_color=1a1b27&hide_border=true&title_color=fbbd23&text_color=c6c6c6'
+interface LanguageStat {
+    name: string;
+    percent: number;
+    color: string;
+}
 
-    const urlItem = [
-        {src: githubStatUrl, alt: "Github Language Stats"},
-        {src: githubLanguageUrl, alt: "Github Stats"},
-    ]
+interface GithubRepo {
+    language: string | null;
+    fork: boolean;
+}
+
+const LANGUAGE_COLORS: Record<string, string> = {
+    TypeScript: '#3178c6',
+    JavaScript: '#f1e05a',
+    Python: '#3572A5',
+    CSS: '#563d7c',
+    HTML: '#e34c26',
+    Java: '#b07219',
+    'C#': '#178600',
+    C: '#555555',
+    'C++': '#f34b7d',
+    Go: '#00ADD8',
+    Rust: '#dea584',
+    PHP: '#4F5D95',
+    Ruby: '#701516',
+    Swift: '#F05138',
+    Kotlin: '#A97BFF',
+    Shell: '#89e051',
+    Dart: '#00B4AB',
+    Vue: '#41b883',
+    SCSS: '#c6538c',
+};
+const FALLBACK_COLOR = '#8b8b8b';
+
+const CARD_BG = '#22232a';
+const CARD_BORDER = '#3a3b44';
+
+export default function GithubLanguage({ isComp }: Props) {
+    const [languages, setLanguages] = useState<LanguageStat[]>([]);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        (async () => {
+            try {
+                const res = await fetch('https://api.github.com/users/Nathapons/repos?per_page=100&type=owner');
+                if (!res.ok) throw new Error('Failed to fetch repositories');
+                const repos: GithubRepo[] = await res.json();
+
+                const counts: Record<string, number> = {};
+                repos
+                    .filter((repo) => !repo.fork && repo.language)
+                    .forEach((repo) => {
+                        const lang = repo.language as string;
+                        counts[lang] = (counts[lang] || 0) + 1;
+                    });
+
+                const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
+                if (total === 0 || cancelled) return;
+
+                const stats = Object.entries(counts)
+                    .map(([name, count]) => ({
+                        name,
+                        percent: Math.round((count / total) * 100),
+                        color: LANGUAGE_COLORS[name] ?? FALLBACK_COLOR,
+                    }))
+                    .sort((a, b) => b.percent - a.percent)
+                    .slice(0, 6);
+
+                if (!cancelled) setLanguages(stats);
+            } catch {
+                // silently ignore — section is omitted when stats are unavailable
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (languages.length === 0) return null;
 
     return (
-        <Row gutter={[0, 2]} className="p-2">
-            {urlItem.map((item, index) => {
-                return (
-                    <Col xl={12} xxl={12} lg={12} md={24} sm={24} xs={24} className='flex justify-center'>
-                        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 2 }}>
-                            <Image 
-                                draggable={false}
-                                key={index} 
-                                src={item.src} 
-                                alt={item.alt} 
-                                preview={false} 
-                                width={(isComp)? 450: 380}
-                                height={200}
-                            />
-                        </motion.div>
-                    </Col>
-                )
-            })}
-        </Row>
-    )
+        <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 1 }}
+            className="flex justify-center mt-6"
+        >
+            <div
+                className="w-full"
+                style={{
+                    maxWidth: 960,
+                    background: CARD_BG,
+                    border: `1px solid ${CARD_BORDER}`,
+                    borderRadius: 16,
+                    padding: isComp ? '28px 32px' : '20px 16px',
+                }}
+            >
+                <div style={{ fontSize: 15, fontWeight: 600, color: '#d9d9db', marginBottom: 16 }}>
+                    Most used languages
+                </div>
+                <div style={{ display: 'flex', width: '100%', height: 10, borderRadius: 6, overflow: 'hidden', gap: 2 }}>
+                    {languages.map((lang) => (
+                        <div key={lang.name} style={{ height: '100%', background: lang.color, width: `${lang.percent}%` }} />
+                    ))}
+                </div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, marginTop: 16 }}>
+                    {languages.map((lang) => (
+                        <div key={lang.name} style={{ display: 'flex', alignItems: 'center', gap: 7, fontSize: 13, color: '#c7c9cf' }}>
+                            <div style={{ width: 10, height: 10, borderRadius: '50%', background: lang.color }} />
+                            <span style={{ fontWeight: 600 }}>{lang.name}</span>
+                            <span style={{ color: '#9a9ca3' }}>{lang.percent}%</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </motion.div>
+    );
 }

--- a/src/components/GithubTitle.tsx
+++ b/src/components/GithubTitle.tsx
@@ -3,7 +3,8 @@ import { Col, ConfigProvider, Row, Typography } from "antd";
 import { GithubOutlined } from "@ant-design/icons";
 import { Props } from '../interfaces/globalInterfaces';
 
-const { Title, Paragraph } = Typography;
+const { Title } = Typography;
+const ACCENT = '#39d353';
 
 
 const GithubTitle: React.FC<Props> = ({ isComp }) => {
@@ -12,15 +13,15 @@ const GithubTitle: React.FC<Props> = ({ isComp }) => {
             theme={{
                 token: {
                     colorText: 'white',
-                    fontSizeHeading3: (isComp ? 35 : 24)
+                    fontSizeHeading3: (isComp ? 38 : 26)
                 },
             }}
         >
-            <Row className="p-2">
+            <Row className="p-2 mb-4">
                 <Col span={24}>
-                    <Title level={3} className="text-center">
-                        <GithubOutlined className="mr-2" />
-                        Github Profile
+                    <Title level={3} className="text-center" style={{ fontWeight: 800, letterSpacing: '-0.5px' }}>
+                        <GithubOutlined className="mr-3" style={{ color: ACCENT }} />
+                        GitHub Profile
                     </Title>
                 </Col>
             </Row>

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,52 +1,80 @@
 import { useState } from 'react';
-import GitHubCalendar from "react-github-calendar";
+import GitHubCalendar, { Activity } from "react-github-calendar";
 import { Props } from '../interfaces/globalInterfaces';
-import { Col, Row, Typography } from "antd";
-import { Select } from 'antd';
+import { ConfigProvider, Select, theme } from "antd";
 import { motion } from "framer-motion"
 
-const { Paragraph } = Typography;
+const CARD_BG = '#22232a';
+const CARD_BORDER = '#3a3b44';
+const ACCENT = '#39d353';
+const GREEN_SCALE = ['#161b22', '#0e4429', '#006d32', '#26a641', '#39d353'];
 
 export default function Timeline({ isComp }: Props) {
     const currentYear = new Date().getFullYear();
     const [selectedYear, setSelectedYear] = useState(String(currentYear));
+    const [totalCount, setTotalCount] = useState<number | null>(null);
 
     const handleYearChange = (year: string) => {
+        setTotalCount(null);
         setSelectedYear(year);
     };
 
+    const transformData = (data: Activity[]) => {
+        setTotalCount(data.reduce((sum, activity) => sum + activity.count, 0));
+        return data;
+    };
+
     return (
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 1 }}>
-            <Row className='text-center mb-6' gutter={[8, 8]}>
-                <Col span={24} className='text-center'>
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 1 }} className="flex flex-col items-center">
+            <div className="mb-8">
+                <ConfigProvider
+                    theme={{
+                        algorithm: theme.darkAlgorithm,
+                        token: { colorPrimary: ACCENT, borderRadius: 10 },
+                    }}
+                >
                     <Select
                         size='large'
-                        defaultValue={selectedYear}
+                        value={selectedYear}
                         style={{ width: 120 }}
                         onChange={handleYearChange}
                         options={Array.from({ length: 5 }, (_, i) => {
-                            return {value: currentYear - i, label: (currentYear - i).toString()}
+                            return { value: String(currentYear - i), label: (currentYear - i).toString() }
                         })}
                     />
-                </Col>
-            </Row>
-            <Row className='flex justify-center'>
-                <Col span={24} className='p-8 bg-card rounded-lg border-2 border-solid border-white w-full max-w-4xl'>
+                </ConfigProvider>
+            </div>
+
+            <div
+                className="w-full"
+                style={{
+                    maxWidth: 960,
+                    background: CARD_BG,
+                    border: `1px solid ${CARD_BORDER}`,
+                    borderRadius: 16,
+                    padding: isComp ? '28px 32px' : '20px 16px',
+                    boxShadow: '0 12px 32px rgba(0,0,0,0.4)',
+                }}
+            >
+                <div style={{ fontSize: 15, fontWeight: 600, color: '#d9d9db', marginBottom: 18, minHeight: 21 }}>
+                    {totalCount !== null ? `${totalCount} contributions in ${selectedYear}` : ' '}
+                </div>
+
+                <div style={{ overflowX: 'auto', paddingBottom: 6 }}>
                     <GitHubCalendar
                         username="Nathapons"
                         year={Number(selectedYear)}
-                        blockSize={16}
-                        blockMargin={4}
-                        fontSize={16}
-                        theme={{
-                            light: ['hsl(0, 0%, 92%)', 'hsl(60, 95%, 80%)', 'hsl(60, 95%, 70%)', 'hsl(60, 95%, 60%)', 'hsl(60, 95%, 50%)'],
-                            dark: ['hsl(0, 0%, 20%)', 'hsl(60, 95%, 30%)', 'hsl(60, 95%, 40%)', 'hsl(60, 95%, 50%)', 'hsl(60, 95%, 60%)'],
-                        }}
-                        hideColorLegend
+                        transformData={transformData}
+                        blockSize={isComp ? 12 : 10}
+                        blockMargin={3}
+                        fontSize={12}
+                        colorScheme="dark"
+                        theme={{ dark: GREEN_SCALE }}
                         hideTotalCount
+                        labels={{ legend: { less: 'Less', more: 'More' } }}
                     />
-                </Col>
-            </Row>
+                </div>
+            </div>
         </motion.div>
     );
 }

--- a/src/pages/GithubTimeline.tsx
+++ b/src/pages/GithubTimeline.tsx
@@ -24,7 +24,7 @@ const GithubTimeline: React.FC = () => {
     <main className="main-content">
         <GithubTitle isComp={isComp} />
         <Timeline isComp={isComp} />
-        {/* <GithubLangauge isComp={isComp} /> */}
+        <GithubLangauge isComp={isComp} />
     </main>
   );
 };


### PR DESCRIPTION
Replace static github-readme-stats images with a live language breakdown fetched from the GitHub API, and restyle the contribution timeline and title with a consistent dark card theme.