### PR TITLE
fix: assign certificate id from index to satisfy CertificateItem type

### DIFF
--- a/src/components/CertificateList.tsx
+++ b/src/components/CertificateList.tsx
@@ -15,7 +15,9 @@ const CertificateList: React.FC<Props> = ({ isComp }) => {
     const [rotation, setRotation] = useState(0)
 
     useEffect(() => {
-        setCertificates(certificateData);
+        setCertificates(
+            certificateData.map((cert, index) => ({ ...cert, id: index }))
+        );
     }, []);
 
     const openModal = (cert: any) => {


### PR DESCRIPTION
Certificate.json entries have no id field, causing a tsc build error since CertificateItem requires one. Derive it from array index instead.