### PR TITLE
chore: sync develop into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.claude
+plan.md

--- a/src/components/CopyRight.tsx
+++ b/src/components/CopyRight.tsx
@@ -29,7 +29,7 @@ const CopyRight: React.FC = () => {
                     },
                 }}
             >
-                <Title level={1}>&#169; Nuthapon.S 2024. All Rights Reserved.</Title>
+                <Title level={1}>&#169; Nuthapon.S 2026. All Rights Reserved.</Title>
             </ConfigProvider>
         </Row>
     );

--- a/src/components/Greeting.tsx
+++ b/src/components/Greeting.tsx
@@ -64,7 +64,7 @@ const Greeting: React.FC<Props> = ({ isComp }) => {
                             <Title level={3}>
                                 I'm <span className="text-amber-400">Nuthapon Sripornprasert</span>
                             </Title>
-                            <Title level={4} className="mb-10"><span className="text-amber-400">Fullstack Developer</span></Title>
+                            <Title level={4} className="mb-10"><span className="text-amber-400">Backend/DevOps Engineer</span></Title>
                             <Paragraph className="mt-2 !mb-0">
                                 <EnvironmentOutlined className="mr-2" />Bangkok, Thailand
                             </Paragraph>
@@ -72,9 +72,9 @@ const Greeting: React.FC<Props> = ({ isComp }) => {
                                 <ManOutlined className="mr-2" />Gender: Male
                             </Paragraph>
                             <Paragraph>
-                                Experienced Backend Developer with a proven track record in designing, developing, and deploying scalable web applications 
-                                using Python/Django. Strong in database management and RESTful APIs. Collaborative and results-driven, seeking a challenging role at NestiFly Co., Ltd. 
-                                to contribute to impactful projects and expand technical skills.
+                                Backend/DevOps Engineer with 4+ years of experience building scalable fintech systems on Python/Django and GCP infrastructure.
+                                Currently expanding into AWS cloud architecture. Seeking a Cloud/DevOps Engineer role to apply infrastructure automation and
+                                regulatory-compliant system design skills.
                             </Paragraph>
                             <Space size="large">
                                 <Button

--- a/src/components/MySkill.tsx
+++ b/src/components/MySkill.tsx
@@ -1,16 +1,18 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Col, ConfigProvider, Image, Row } from "antd";
 import styled from "styled-components";
 import { Typography } from 'antd';
 import { Props } from "../interfaces/globalInterfaces";
 import Marquee from "react-fast-marquee";
-import mySkillData from '../data/MySkill.json';
+import languageSkillData from '../data/MySkill.json';
+import cloudSkillData from '../data/CloudSkill.json';
 import { TechStackItem } from "../interfaces/globalInterfaces";
 
 const MySkillCol = styled(Col)`
     display: flex;
     align-items: center;
     justify-content: center;
+    min-width: 0;
     padding: 10px 15px;
 
     @media (min-width: 1050px) {
@@ -20,67 +22,90 @@ const MySkillCol = styled(Col)`
     }
 `;
 
+const SkillSection = styled.div`
+    width: 100%;
+    min-width: 0;
+    overflow: hidden;
+    padding: 30px 0;
+`;
+
+const SkillCard = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 16px 20px;
+    margin: 0 8px;
+    background-color: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 14px;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+
+    &:hover {
+        background-color: rgba(255, 255, 255, 0.1);
+        transform: translateY(-2px);
+    }
+`;
+
 const { Title } = Typography;
 
+interface SkillGroupProps extends Props {
+    title: string;
+    skills: TechStackItem[];
+}
+
+const SkillGroup: React.FC<SkillGroupProps> = ({ isComp, title, skills }) => (
+    <SkillSection>
+        <Row style={isComp ? { margin: '0 auto' } : {}}>
+            <MySkillCol span={24}>
+                <Col span={24}>
+                    <ConfigProvider
+                        theme={{
+                            token: {
+                                colorText: '#ffcc00',
+                                fontSizeHeading3: (isComp ? 35 : 24)
+                            },
+                        }}
+                    >
+                        <Title level={3} style={{ textAlign: 'center' }}>{title}</Title>
+                    </ConfigProvider>
+                </Col>
+            </MySkillCol>
+            <MySkillCol span={24}>
+                <Marquee pauseOnHover gradient gradientColor="#34353a" gradientWidth={isComp ? 80 : 30}>
+                    {skills.map((item, index) => {
+                        return (
+                            <SkillCard key={index}>
+                                <Image
+                                    src={item.src}
+                                    alt={item.alt}
+                                    width={isComp ? 60 : 36}
+                                    preview={false}
+                                />
+                                <ConfigProvider
+                                    theme={{
+                                        token: {
+                                            colorText: 'white'
+                                        },
+                                    }}
+                                >
+                                    <Title level={5} style={{ margin: 0, whiteSpace: 'nowrap' }}>{item.alt}</Title>
+                                </ConfigProvider>
+                            </SkillCard>
+                        );
+                    })}
+                </Marquee>
+            </MySkillCol>
+        </Row>
+    </SkillSection>
+);
+
 const MySkill: React.FC<Props> = ({ isComp }) => {
-    const [skills, setSkills] = useState<TechStackItem[]>([]);
-
-    useEffect(() => {
-        // Using imported JSON data directly
-        setSkills(mySkillData);
-    }, []);
-
     return (
         <Row>
-            <Row style={isComp ? { margin: '0 auto'} : {}}>
-                <MySkillCol span={24}>
-                    <Col span={24}>
-                        <ConfigProvider
-                            theme={{
-                                token: {
-                                    colorText: '#ffcc00',
-                                    fontSizeHeading3: (isComp ? 35 : 24)
-                                },
-                            }}
-                        >
-                            <Title level={3} style={{ textAlign: 'center' }}>Programming Skills</Title>
-                        </ConfigProvider>
-                    </Col>
-                </MySkillCol>
-                <MySkillCol span={24}>
-                    <Marquee pauseOnHover={false}>
-                        <Row gutter={isComp ? [20, 0] : [5, 0]}>
-                            {skills.map((item, index) => {
-                                return (
-                                    <Col key={index}>
-                                        <Row gutter={[0, 10]} align="middle" justify="center">
-                                            <Col span={24} style={{display: 'flex', justifyContent: "center"}}>
-                                                <Image 
-                                                    src={item.src} 
-                                                    alt={item.alt} 
-                                                    width={isComp ? 70 : 40} 
-                                                    preview={false}
-                                                />
-                                            </Col>
-                                            <Col span={24} style={{display: 'flex', justifyContent: "center"}}>
-                                                <ConfigProvider
-                                                    theme={{
-                                                        token: {
-                                                            colorText: 'white'
-                                                        },
-                                                    }}
-                                                >
-                                                    <Title level={5}>{item.alt}</Title>
-                                                </ConfigProvider>
-                                            </Col>
-                                        </Row>
-                                    </Col>
-                                );
-                            })}
-                        </Row>
-                    </Marquee>
-                </MySkillCol>
-            </Row>
+            <SkillGroup isComp={isComp} title="Languages & Frameworks" skills={languageSkillData} />
+            <SkillGroup isComp={isComp} title="Cloud & DevOps" skills={cloudSkillData} />
         </Row>
     );
 };

--- a/src/data/CloudSkill.json
+++ b/src/data/CloudSkill.json
@@ -1,0 +1,26 @@
+[
+    {
+        "src": "https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/skills/aws-colored.svg",
+        "alt": "AWS"
+    },
+    {
+        "src": "https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/skills/googlecloud-colored.svg",
+        "alt": "Google Cloud"
+    },
+    {
+        "src": "https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/skills/docker-colored.svg",
+        "alt": "Docker"
+    },
+    {
+        "src": "https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/skills/kubernetes-colored.svg",
+        "alt": "Kubernetes"
+    },
+    {
+        "src": "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/redis/redis-original.svg",
+        "alt": "Redis"
+    },
+    {
+        "src": "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/githubactions/githubactions-plain.svg",
+        "alt": "CI/CD"
+    }
+]


### PR DESCRIPTION
## Summary
- Split skills marquee into Languages & Frameworks and Cloud & DevOps sections (new CloudSkill.json)
- Refreshed Greeting bio/title for Backend/DevOps focus
- Bumped copyright year to 2026

## Test plan
- [ ] Verify GitHub Pages deploy renders both skill marquees correctly